### PR TITLE
Force orientation only to internal display.

### DIFF
--- a/src/drm.cpp
+++ b/src/drm.cpp
@@ -1248,25 +1248,33 @@ drm_prepare_basic( struct drm_t *drm, const struct FrameInfo_t *frameInfo )
 
 	drm->fbids_in_req.push_back( fb_id );
 
-	switch ( g_drmModeOrientation )
+	drm_screen_type screenType = drm_get_screen_type(drm);
+	if ( screenType == DRM_SCREEN_TYPE_INTERNAL )
 	{
-	case PANEL_ORIENTATION_0:
-		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_0);
-		break;
-	case PANEL_ORIENTATION_270:
-		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_270);
-		break;
-	case PANEL_ORIENTATION_90:
-		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_90);
-		break;
-	case PANEL_ORIENTATION_180:
-		add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_180);
-		break;
-	/* we are keeping the original method used for by default to prevent a sudden break in compatibility for devices using this method.*/
-	case PANEL_ORIENTATION_AUTO:
-	default:
+		switch ( g_drmModeOrientation )
+		{
+		case PANEL_ORIENTATION_0:
+			add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_0);
+			break;
+		case PANEL_ORIENTATION_270:
+			add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_270);
+			break;
+		case PANEL_ORIENTATION_90:
+			add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_90);
+			break;
+		case PANEL_ORIENTATION_180:
+			add_plane_property(req, drm->primary, "rotation", DRM_MODE_ROTATE_180);
+			break;
+		/* we are keeping the original method used for by default to prevent a sudden break in compatibility for devices using this method.*/
+		case PANEL_ORIENTATION_AUTO:
+		default:
+			add_plane_property(req, drm->primary, "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+			break;
+		}
+	}
+	else
+	{
 		add_plane_property(req, drm->primary, "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
-		break;
 	}
 
 	add_plane_property(req, drm->primary, "FB_ID", fb_id);
@@ -1404,25 +1412,34 @@ drm_prepare_liftoff( struct drm_t *drm, const struct FrameInfo_t *frameInfo )
 				crtcH = w;
 			}
 
-			switch ( g_drmModeOrientation )
+			drm_screen_type screenType = drm_get_screen_type(drm);
+			if ( screenType == DRM_SCREEN_TYPE_INTERNAL )
 			{
-				case PANEL_ORIENTATION_0:
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_0);
-					break;
-				case PANEL_ORIENTATION_270:
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_270);
-					break;
-				case PANEL_ORIENTATION_90:
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_90);
-					break;
-				case PANEL_ORIENTATION_180:
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_180);
-					break;
-				case PANEL_ORIENTATION_AUTO:
-				default: /* We are using auto to ensure compatibility with devicess that used this method*/
-					liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
-					break;
+				switch ( g_drmModeOrientation )
+				{
+					case PANEL_ORIENTATION_0:
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_0);
+						break;
+					case PANEL_ORIENTATION_270:
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_270);
+						break;
+					case PANEL_ORIENTATION_90:
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_90);
+						break;
+					case PANEL_ORIENTATION_180:
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", DRM_MODE_ROTATE_180);
+						break;
+					case PANEL_ORIENTATION_AUTO:
+					default: /* We are using auto to ensure compatibility with devicess that used this method*/
+						liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+						break;
+				}
 			}
+			else
+			{
+				liftoff_layer_set_property( drm->lo_layers[ i ], "rotation", g_bRotated ? DRM_MODE_ROTATE_270 : DRM_MODE_ROTATE_0);
+			}
+
 
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_X", crtcX);
 			liftoff_layer_set_property( drm->lo_layers[ i ], "CRTC_Y", crtcY);


### PR DESCRIPTION
I'm using holoiso with Ayaneo Air. I find an issue that if I connect it to an external monitor in deck UI, the picture is stretched and rotated. See the picture below. The handheld built-in display is good. The external display also works fine in desktop mode.

![image](https://user-images.githubusercontent.com/71942669/188036061-af3e885e-b4de-4d0d-9091-59942cc9a740.png)

It's a fix to this issue: https://github.com/theVakhovskeIsTaken/holoiso/issues/489

Let me know if I try submitting the PR to a different repo instead.
